### PR TITLE
fix: 로그인 페이지 버그 수정

### DIFF
--- a/src/actions/login.ts
+++ b/src/actions/login.ts
@@ -5,21 +5,29 @@ import { ErrorSchema } from "@/schema/error";
 import { LoginFormSchema } from "@/schema/login";
 import { api } from "@/utils/api";
 
+const ERROR_MSG = {
+  credentials: "* 잘못된 아이디 또는 비밀번호입니다.",
+  token: "* 사용자 정보를 검증할 수 없습니다. 관리자에 문의해 주세요.",
+};
+
 export async function login(credentials: { username: string; password: string }) {
   const validatedForm = LoginFormSchema.safeParse(credentials);
   if (validatedForm.success) {
     try {
       const res = await api.post("/api/v1/users/sign-in", credentials);
-      console.log(res);
       if (res.ok) {
         const bearerToken = res.headers.get("Authorization");
-        if (!bearerToken) return;
+        if (!bearerToken)
+          return {
+            isValid: false,
+            errors: { credentials: [ERROR_MSG.token] },
+          };
         const accessToken = bearerToken.split("Bearer ")[1];
         const payload = await verifyAuth(accessToken);
         saveSession(accessToken, payload.exp * 1000);
         return { isValid: true };
       }
-      return { isValid: false, invalidCredentials: true };
+      return { isValid: false, errors: { credentials: [ERROR_MSG.credentials] } };
     } catch (e) {
       const isError = ErrorSchema.safeParse(e);
       if (isError.success) {

--- a/src/components/login/LogInForm.tsx
+++ b/src/components/login/LogInForm.tsx
@@ -2,101 +2,67 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import Cancel from "@mui/icons-material/Cancel";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
-import { Button, FormHelperText, IconButton, TextField } from "@mui/material";
+import Button from "@mui/material/Button";
+import FormHelperText from "@mui/material/FormHelperText";
+import IconButton from "@mui/material/IconButton";
+import TextField from "@mui/material/TextField";
 import useAuthContext from "@/hooks/useAuthContext";
-import useForm from "@/hooks/useForm";
 import { login } from "@/actions/login";
 
 export default function LoginForm() {
-  const { formData, updateFormData } = useForm(["username", "password"]);
-  const [showPassword, setShowPassword] = useState(false);
-  const [isCredentialError, setIsCredentialError] = useState(false);
-  const [pending, setPending] = useState(false);
   const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [error, setError] = useState<{ [key: string]: string[] | undefined }>({});
+  const [pending, setPending] = useState(false);
   const { updateSession } = useAuthContext();
-
-  const handleInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const input = e.target.value;
-    const name = e.target.name;
-    updateFormData(name, input);
-  };
 
   const handlePasswordVisibility = () => setShowPassword(!showPassword);
 
-  const clearInput = (key: string) => updateFormData(key, "");
-
-  const handleLogin = async (e: React.FormEvent) => {
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setPending(true);
+    const form = e.currentTarget;
+    const formData = new FormData(form);
     const loginCredentials = {
-      username: formData.username.value as string,
-      password: formData.password.value as string,
+      username: formData.get("username") as string,
+      password: formData.get("password") as string,
     };
     const res = await login(loginCredentials);
-    if (res?.isValid) {
+    if (res.isValid) {
       updateSession({ isLoggedIn: true });
       return router.push("/");
-    } else if (res?.errors) {
-      updateFormData("username", formData.username.value, true, res?.errors.username && res?.errors.username[0]);
-      updateFormData("password", formData.password.value, true, res?.errors.password && res?.errors.password[0]);
-      setPending(false);
-      return;
+    } else if (res.errors) {
+      setError(res.errors);
     }
-    setIsCredentialError(true);
     setPending(false);
   };
 
   return (
     <form onSubmit={handleLogin} className="flex flex-col w-56 sm:w-80 gap-4">
       <div>
-        <TextField
-          name="username"
-          size="small"
-          placeholder="아이디"
-          value={formData.username.value}
-          onChange={handleInput}
-          fullWidth
-          InputProps={{
-            endAdornment:
-              formData.username.value !== "" ? (
-                <IconButton size="small" onClick={() => clearInput("username")}>
-                  <Cancel fontSize="small" />
-                </IconButton>
-              ) : null,
-          }}
-        />
-        {formData.username.error && <FormHelperText error>{formData.username.errorMsg}</FormHelperText>}
+        <TextField name="username" size="small" placeholder="아이디" fullWidth />
+        {error.username && <FormHelperText error>{error.username[0]}</FormHelperText>}
       </div>
       <div>
         <TextField
           name="password"
           size="small"
           placeholder="비밀번호"
-          value={formData.password.value}
           type={showPassword ? "text" : "password"}
-          onChange={handleInput}
           fullWidth
           InputProps={{
             endAdornment: (
-              <>
-                <IconButton size="small" onClick={handlePasswordVisibility}>
-                  {showPassword ? <Visibility fontSize="small" /> : <VisibilityOff fontSize="small" />}
-                </IconButton>
-                {formData.password.value !== "" ? (
-                  <IconButton size="small" onClick={() => clearInput("password")}>
-                    <Cancel fontSize="small" />
-                  </IconButton>
-                ) : null}
-              </>
+              <IconButton size="small" onClick={handlePasswordVisibility}>
+                {showPassword ? <Visibility fontSize="small" /> : <VisibilityOff fontSize="small" />}
+              </IconButton>
             ),
           }}
         />
-        {formData.password.error && <FormHelperText error>{formData.password.errorMsg}</FormHelperText>}
+        {error.password && <FormHelperText error>{error.password[0]}</FormHelperText>}
       </div>
-      {isCredentialError && <FormHelperText error>* 잘못된 아이디 또는 비밀번호입니다.</FormHelperText>}
+      {error.credentials && <FormHelperText error>{error.credentials[0]}</FormHelperText>}
       <Button type="submit" variant="contained" size="large" className="mt-6" disabled={pending} disableElevation>
         로그인
       </Button>


### PR DESCRIPTION
## 작업 내용

- 브라우저의 로그인 정보 자동입력 기능을 사용했을 때 로그인 폼의 인풋값을 컴포넌트의 상태로 제어하고 있던 이유로 인해 비밀번호 숨기기/보이기 버튼을 눌렀을 때 기존에 빈 배열이었던 상태값이 반영되어, 비밀번호 필드의 값이 빈 값으로 반영되는 현상을 수정했습니다
- `username` 및 `password` 값을 더이상 상태로 관리하지 않는 관계로 필드값 우측의 인풋 초기화 버튼을 제거했습니다