### PR TITLE
refactor: 세션 관리 로직 수정

### DIFF
--- a/src/actions/login.ts
+++ b/src/actions/login.ts
@@ -10,7 +10,10 @@ const ERROR_MSG = {
   token: "* 사용자 정보를 검증할 수 없습니다. 관리자에 문의해 주세요.",
 };
 
-export async function login(credentials: { username: string; password: string }) {
+export async function login(
+  credentials: { username: string; password: string },
+  sessionCheck: null | FormDataEntryValue
+) {
   const validatedForm = LoginFormSchema.safeParse(credentials);
   if (validatedForm.success) {
     try {
@@ -24,7 +27,8 @@ export async function login(credentials: { username: string; password: string })
           };
         const accessToken = bearerToken.split("Bearer ")[1];
         const payload = await verifyAuth(accessToken);
-        saveSession(accessToken, payload.exp * 1000);
+        if (sessionCheck === null) saveSession(accessToken);
+        else saveSession(accessToken, payload.exp * 1000);
         return { isValid: true };
       }
       return { isValid: false, errors: { credentials: [ERROR_MSG.credentials] } };

--- a/src/components/login/LogInForm.tsx
+++ b/src/components/login/LogInForm.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
 import Button from "@mui/material/Button";
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
 import FormHelperText from "@mui/material/FormHelperText";
 import IconButton from "@mui/material/IconButton";
 import TextField from "@mui/material/TextField";
@@ -29,7 +31,7 @@ export default function LoginForm() {
       username: formData.get("username") as string,
       password: formData.get("password") as string,
     };
-    const res = await login(loginCredentials);
+    const res = await login(loginCredentials, formData.get("session"));
     if (res.isValid) {
       updateSession({ isLoggedIn: true });
       return router.push("/");
@@ -40,7 +42,7 @@ export default function LoginForm() {
   };
 
   return (
-    <form onSubmit={handleLogin} className="flex flex-col w-56 sm:w-80 gap-4">
+    <form onSubmit={handleLogin} className="flex flex-col w-56 sm:w-80 gap-2">
       <div>
         <TextField name="username" size="small" placeholder="아이디" fullWidth />
         {error.username && <FormHelperText error>{error.username[0]}</FormHelperText>}
@@ -62,10 +64,15 @@ export default function LoginForm() {
         />
         {error.password && <FormHelperText error>{error.password[0]}</FormHelperText>}
       </div>
+      <div>
+        <FormControlLabel label="로그인 유지" name="session" control={<Checkbox size="small" />} />
+      </div>
       {error.credentials && <FormHelperText error>{error.credentials[0]}</FormHelperText>}
-      <Button type="submit" variant="contained" size="large" className="mt-6" disabled={pending} disableElevation>
-        로그인
-      </Button>
+      <div className="mt-6 w-full">
+        <Button type="submit" variant="contained" size="large" disabled={pending} fullWidth disableElevation>
+          로그인
+        </Button>
+      </div>
     </form>
   );
 }

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -11,7 +11,7 @@ type UserJwtPayload = {
 };
 
 // Functions for JWT verification
-export const getJwtSecretKey = () => {
+const getJwtSecretKey = () => {
   const secret = process.env.JWT_SECRET;
   if (!secret || secret.length === 0) {
     throw new Error("Missing JWT secret key.");
@@ -26,13 +26,13 @@ export async function verifyAuth(token: string) {
 }
 
 // Session functions
-export async function saveSession(value: string, expires: number) {
+export async function saveSession(value: string, expires?: number) {
   cookies().set("knous", value, {
     httpOnly: true,
     secure: true,
-    expires,
     sameSite: "lax",
     path: "/",
+    ...(expires && { expires }),
   });
 }
 


### PR DESCRIPTION
## 작업 내용

- 로그인 페이지에 로그인 유지 옵션을 추가했습니다
- 사용자가 로그인 유지를 선택할 경우 JWT 토큰을 만료기간만큼 쿠키에 저장하고, 로그인 유지를 선택하지 않을 경우 토큰을 세션 쿠키에 저장합니다