### PR TITLE
feat: 강의 미리보기 컴포넌트에 리뷰 갯수 추가

### DIFF
--- a/src/app/api/courses/route.ts
+++ b/src/app/api/courses/route.ts
@@ -1,41 +1,37 @@
 import { NextRequest, NextResponse } from "next/server";
 import { api } from "@/utils/api";
+import { ErrorSchema } from "@/schema/error";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const idQuery = searchParams.get("id");
   const pageQuery = searchParams.get("page");
+  let endpointUrl: string;
 
   if (idQuery) {
-    try {
-      const res = await api.get(`/api/v1/course/${idQuery}`);
-      if (res.status === 200) {
-        const body = await res.json();
-        return NextResponse.json(body.data);
-      }
-    } catch (e) {
-      console.log(e);
-    }
+    endpointUrl = `/api/v1/course/${idQuery}`;
   } else if (pageQuery) {
-    try {
-      const res = await api.get(`/api/v2/courses?page=${pageQuery}`);
-      if (res.status === 200) {
-        const body = await res.json();
-        return NextResponse.json(body.data);
-      }
-    } catch (e) {
-      console.log(e);
-    }
+    endpointUrl = `/api/v2/courses?page=${pageQuery}`;
   } else {
-    try {
-      const res = await api.get("/api/v1/courses");
-      if (res.status === 200) {
-        const body = await res.json();
-        return NextResponse.json(body.data);
-      }
-    } catch (e) {
-      console.log(e);
-    }
+    endpointUrl = "/api/v2/courses";
   }
-  return NextResponse.json({});
+
+  try {
+    const res = await api.get(endpointUrl);
+    if (res.status === 200) {
+      const pageBody = await res.json();
+      if (pageBody.data.content.length === 0) return NextResponse.json({ ...pageBody.data, likes: [] });
+      const courseIds = pageBody.data.content.map((item: any) => item.id);
+      const reviewsQuery = courseIds.map((id: number) => "courseIds=" + id.toString()).join("&");
+      const reviewsRes = await api.get(`/api/v1/review-count?${reviewsQuery}`);
+      const reviewsBody = await reviewsRes.json();
+      return NextResponse.json({ ...pageBody.data, reviews: reviewsBody.data });
+    }
+  } catch (e) {
+    const isError = ErrorSchema.safeParse(e);
+    if (isError.success) {
+      console.log((e as Error).message);
+    } else console.log(e);
+  }
+  return NextResponse.error();
 }

--- a/src/components/course/CourseListContainer.tsx
+++ b/src/components/course/CourseListContainer.tsx
@@ -5,8 +5,18 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import CoursePreview, { type CoursePreviewProps } from "./CoursePreview";
 import CoursePreviewSkeleton from "./CoursePreviewSkeleton";
 import PageNavigator from "../common/PageNavigator";
+import { STALE_TIME } from "@/constants/query";
 
 const fetchAllCourses = (page = "1") => fetch(`/api/courses?page=${page}`).then((res) => res.json());
+
+const select = (data: any) => {
+  const combinedContent = data.content.map((course: any) => {
+    const [reviews] = data.reviews.filter((reviewData: any) => reviewData.courseId === course.id);
+    return { ...course, reviews };
+  });
+  console.log(combinedContent);
+  return { ...data, content: combinedContent };
+};
 
 export default function CourseListContainer({ page }: { page?: string }) {
   const router = useRouter();
@@ -14,6 +24,9 @@ export default function CourseListContainer({ page }: { page?: string }) {
     queryKey: ["all-courses", page],
     queryFn: () => fetchAllCourses(page),
     placeholderData: keepPreviousData,
+    select,
+    refetchOnWindowFocus: false,
+    staleTime: STALE_TIME.courses,
   });
 
   const handlePageSelect = (value = "1") => {

--- a/src/components/course/CoursePreview.tsx
+++ b/src/components/course/CoursePreview.tsx
@@ -9,6 +9,7 @@ export type CoursePreviewProps = {
   classification: string;
   grade: number;
   semester: string;
+  reviews: { courseId: number; reviewCount: number };
 };
 
 export default function CoursePreview({
@@ -19,6 +20,7 @@ export default function CoursePreview({
   classification,
   grade,
   semester,
+  reviews,
 }: CoursePreviewProps) {
   return (
     <Link href={`/courses/${id}`} className="w-full">
@@ -33,7 +35,9 @@ export default function CoursePreview({
         </div>
         <div className="flex flex-col justify-between items-end">
           <Label text={classification} background="bg-[#1b60c6]" display="inline-block" />
-          <div>상세 보기</div>
+          <div>
+            리뷰 <span className="text-[#65a3ff]">{reviews.reviewCount.toLocaleString("ko-KR")}</span>
+          </div>
         </div>
       </div>
     </Link>

--- a/src/components/course/CourseReviewContainer.tsx
+++ b/src/components/course/CourseReviewContainer.tsx
@@ -50,6 +50,7 @@ export default function CourseReviewContainer({ courseId }: CourseReviewContaine
     queryFn: () => fetchAllReviews(page, courseId),
     placeholderData: keepPreviousData,
     select,
+    refetchOnWindowFocus: false,
   });
 
   const handlePageSelect = (value = "1") => setPage(Number(value));

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -6,6 +6,7 @@ import CoursePreview, { type CoursePreviewProps } from "../course/CoursePreview"
 import CoursePreviewSkeleton from "../course/CoursePreviewSkeleton";
 import NoResults from "./NoResults";
 import PageNavigator from "../common/PageNavigator";
+import { STALE_TIME } from "@/constants/query";
 import type { CourseSearchParams } from "@/app/search/page";
 
 const fetchCourses = (page: string, searchType: string, name: string) =>
@@ -17,6 +18,8 @@ export default function SearchResults({ searchType, name, page }: CourseSearchPa
     queryKey: ["search-results", page, searchType, name],
     queryFn: () => fetchCourses(page, searchType, name),
     placeholderData: keepPreviousData,
+    refetchOnWindowFocus: false,
+    staleTime: STALE_TIME.courses,
   });
 
   const handlePageSelect = (value = "1") => {

--- a/src/constants/query.ts
+++ b/src/constants/query.ts
@@ -1,0 +1,3 @@
+export const STALE_TIME = {
+  courses: 1000 * 60 * 30,
+};


### PR DESCRIPTION
## 작업 내용

- 강의 상세 페이지에 진입하기 전에 리뷰가 있는 강의인지 사용자가 알 수 있도록, 강의 미리보기 카드 컴포넌트에 해당 강의에 달린 리뷰 갯수를 표기하도록 개선했습니다
  ![image](https://github.com/user-attachments/assets/b566ccfb-fea7-4443-8353-fd631a65380e)
- 기존에 미리보기 컴포넌트에 있었던 `상세 보기` 텍스트는 사용자의 혼동을 줄이기 위해 삭제하였습니다
- 강의 및 리뷰 데이터에 대한 refetch가 너무 자주 일어나지 않도록 TanStack Query의 refetch 조건을 변경했습니다
  - window visibility 변동으로 인한 refetch 기능을 off 처리
  - 강의 fetch stale time을 30분으로 수정