### PR TITLE
fix: 공지 목록 페이지 버그 수정

### DIFF
--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,5 +1,5 @@
 import PostTable from "@/components/news/PostTable";
-import { getSortedPosts } from "@/lib/post";
+import { getPosts } from "@/lib/post";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -7,8 +7,7 @@ export const metadata: Metadata = {
 };
 
 export default async function News() {
-  const posts = await getSortedPosts();
-  console.log(posts);
+  const posts = await getPosts();
   return (
     <div className="flex flex-col w-[93dvw] min-h-[80dvh] xl:w-[950px] pt-10 pb-24 xl:py-24 gap-4">
       <h1 className="text-xl sm:text-2xl font-bold">공지</h1>

--- a/src/lib/post/index.ts
+++ b/src/lib/post/index.ts
@@ -18,24 +18,28 @@ type PostContent = PostData & {
 
 const postsDirectory = path.join(process.cwd(), "news");
 
-export async function getSortedPosts(): Promise<PostData[]> {
+export function getSortedPosts(): PostData[] {
   const fileNames = fs.readdirSync(postsDirectory);
-  console.log(fileNames);
   const allPosts = fileNames.map((fileName) => {
     const id = fileName.replace(/\.md$/, "");
     const fullPath = path.join(postsDirectory, fileName);
     const fileContents = fs.readFileSync(fullPath, "utf8");
-    console.log(fileContents);
+
     const matterResult = matter(fileContents);
     return { id, ...matterResult.data } as PostData;
   });
   return allPosts.sort((a, b) => b.date.localeCompare(a.date));
 }
 
+export async function getPosts() {
+  const posts = getSortedPosts();
+  return posts;
+}
+
 export async function getPostContent(id: string) {
   const fullPath = path.join(postsDirectory, `${id}.md`);
   const fileContents = fs.readFileSync(fullPath, "utf8");
-  console.log(fileContents);
+
   const matterResult = matter(fileContents);
   const processedContent = await remark().use(html).process(matterResult.content);
   const contentHtml = processedContent.toString();


### PR DESCRIPTION
## 작업 내용

- 공지글 목록이 보이지 않던 이슈를 해결했습니다 (원인: 서버 함수는 async여야 하나 공지글 목록을 파일 디렉토리에서 불러오는 함수는 동기적인 함수여서 함수가 제대로 실행되지 않음)